### PR TITLE
make quality nullable and add size field of type int

### DIFF
--- a/video.go
+++ b/video.go
@@ -53,12 +53,13 @@ type User struct {
 
 type VideoFile struct {
 	ID       int     `json:"id"`
-	Quality  string  `json:"quality"`
+	Quality  *string `json:"quality"`
 	FileType string  `json:"file_type"`
 	Width    int     `json:"width"`
 	Height   int     `json:"height"`
 	FPS      float32 `json:"fps"`
 	Link     string  `json:"link"`
+	Size     int     `json:"size"`
 }
 
 type VideoPicture struct {


### PR DESCRIPTION
There is an undocumented size field that I need to access for my application.

Additionally, I noticed with this specific file that i just happen to stumble on that the quality field can return a null value, so I made quality nullable by setting it to a pointer. This is obviously a breaking change, but should be easy to account for.

```
curl -X GET 'https://api.pexels.com/videos/videos/28487839' \
  --header 'Authorization: [REDACTED]'

{
  "id": 28487839,
  "width": 3840,
  "height": 2160,
  "duration": 12,
  "full_res": null,
  "tags": [],
  "url": "https://www.pexels.com/video/peace-28487839/",
  "image": "https://images.pexels.com/videos/28487839/colombia-colombian-city-peace-southamerica-28487839.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=630&w=1200",
  "avg_color": null,
  "user": {
    "id": 1844388701,
    "name": "Haymo Joseph",
    "url": "https://www.pexels.com/@haymo-joseph-1844388701"
  },
  "video_files": [
    {
      "id": 12396492,
      "quality": null,
      "file_type": "video/mp4",
      "width": 640,
      "height": 360,
      "fps": 120,
      "link": "https://videos.pexels.com/video-files/28487839/12396492_640_360_120fps.mp4",
      "size": 661557
    },
...TRUNCATED
  ],
  "video_pictures": [
    {
      "id": 23093336,
      "nr": 0,
      "picture": "https://images.pexels.com/videos/28487839/pictures/preview-0.jpg"
    },
    ....TRUNCATED
  ]
}

```